### PR TITLE
Fix ignored width parameter in str_rmd_wrap.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,6 @@ Imports:
 Suggests: 
     testthat
 LazyData: true
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.0
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ a `r max(iris$Sepal.Length)`, viverra nisl at, luctus ante =
 Then go to Tools > Addins in RStudio to select and configure addins. I've mapped 
 this one addin to the shortcut `Ctrl + Shift + Alt + /`.
 
-Currently, the package wraps lines using a maximum line width of 80 characters.
+The package wraps lines using a maximum width set by `options("WrapRmd.width")`
+which currently defaults to `80` characters.
 
 It should work on multiple paragraphs:
 

--- a/man/WrapRmd.Rd
+++ b/man/WrapRmd.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{WrapRmd}
 \alias{WrapRmd}
-\alias{WrapRmd-package}
 \title{WrapRmd}
 \description{
 Provides an RStudio addin for wrapping paragraphs in an RMarkdown document

--- a/man/str_rmd_wrap.Rd
+++ b/man/str_rmd_wrap.Rd
@@ -4,12 +4,12 @@
 \alias{str_rmd_wrap}
 \title{Wrap text but don't insert lines breaks into inline R code}
 \usage{
-str_rmd_wrap(string, width = 80)
+str_rmd_wrap(string, width = getOption("WrapRmd.width", 80))
 }
 \arguments{
 \item{string}{a string to wrap}
 
-\item{width}{desired line width. Defaults to 80 characters.}
+\item{width}{desired line width. Defaults to \code{options("WrapRmd.width")}.}
 }
 \value{
 a wrapped copy of the string

--- a/man/wrap_rmd_addin.Rd
+++ b/man/wrap_rmd_addin.Rd
@@ -9,3 +9,9 @@ wrap_rmd_addin()
 \description{
 Call this addin to wrap paragraphs in an R Markdown document.
 }
+\details{
+The maximum line width can be set via \code{options(WrapRmd.width)}.
+Further fine tuning can be done via options \dQuote{WrapRmd.smart} and
+\dQuote{WrapRmd.extensions}, which are passed down to
+\code{\link{markdown_commonmark}}.
+}

--- a/tests/testthat/test-wrap.R
+++ b/tests/testthat/test-wrap.R
@@ -116,3 +116,30 @@ text in p2.
 "
   expect_equal(str_rmd_wrap(paragraphs_sttsts), paragraphs_sttsts_wrapped)
 })
+
+test_that("set column width directly", {
+  long_paragraph <- paste(sprintf("a%02d", 3 + 4 * 0:20) , collapse = " ")
+
+  long_paragraph_wrap_10 <-
+"a03 a07
+a11 a15
+a19 a23
+a27 a31
+a35 a39
+a43 a47
+a51 a55
+a59 a63
+a67 a71
+a75 a79
+a83"
+  long_paragraph_wrap_40 <-
+"a03 a07 a11 a15 a19 a23 a27 a31 a35 a39
+a43 a47 a51 a55 a59 a63 a67 a71 a75 a79
+a83"
+  long_paragraph_wrap_default <-
+"a03 a07 a11 a15 a19 a23 a27 a31 a35 a39 a43 a47 a51 a55 a59 a63 a67 a71 a75 a79
+a83"
+  expect_equal(str_rmd_wrap(long_paragraph, 10), long_paragraph_wrap_10)
+  expect_equal(str_rmd_wrap(long_paragraph, 40), long_paragraph_wrap_40)
+  expect_equal(str_rmd_wrap(long_paragraph), long_paragraph_wrap_default)
+})


### PR DESCRIPTION
The width parameter was not passed down to internal functions
properly and documentation was not up to date. This is fixed in this
commit.

Internal functions were stripped of default arugments, as they
are anyways supposed only to be called by API functions. This avoids
setting the same default over and over again.

A test case was added to check whether the argument `width` is
properly handled by all functions.

Closes #12.