### PR TITLE
Avoid adding line breaks in between `bookdown` cross-references

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: WrapRmd
 Title: RStudio Addin for Wrapping RMarkdown Paragraphs
-Version: 0.0.0.9003
+Version: 0.0.0.9004
 Authors@R:
     person("Tristan", "Mahr", , "tristan.mahr@wisc.edu", role = c("aut", "cre"))
 Description: Provides an RStudio addin for wrapping paragraphs in an RMarkdown

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# WrapRmd 0.0.0.9004
+
+* Added support for avoiding inserting line breaks into `bookdown` cross-references (such as `Figure\ \@ref(fig:example)`).
+
 # WrapRmd 0.0.0.9003
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,3 @@
+# WrapRmd 0.0.0.9003
+
+* Added a `NEWS.md` file to track changes to the package.

--- a/tests/testthat/test-wrap.R
+++ b/tests/testthat/test-wrap.R
@@ -34,6 +34,20 @@ It's very easy to make some words **bold** and a [link to
 Google!](http://google.com)!
 "
 
+    expect_equal(str_rmd_wrap(string), string2)
+})
+
+test_that("does not break cross-references (#16)", {
+  string <- "
+Here is some inline code `r hello` and cross-references to Figure\\ \\@ref(fig:test-figure). Also Table\\ \\@ref(tab:test-table) and\\ \\@ref(fig:test-figure).
+"
+
+  string2 <- "
+Here is some inline code `r hello` and cross-references to
+Figure\\ \\@ref(fig:test-figure). Also Table\\ \\@ref(tab:test-table)
+and\\ \\@ref(fig:test-figure).
+"
+
   expect_equal(str_rmd_wrap(string), string2)
 })
 


### PR DESCRIPTION
- Fixes https://github.com/tjmahr/WrapRmd/issues/16.

- Makes the line break ignoring capability more general, so that more patterns
can be potentially added in the future.